### PR TITLE
Redacted mode: make spoiler content accessible

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "com.github.moussetc.mattermost.plugin.spoiler",
     "name": "Spoiler Command",
     "description": "This plugin defines a /spoiler command.",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "homepage_url":"https://github.com/moussetc/mattermost-plugin-spoiler/",
     "support_url":"https://github.com/moussetc/mattermost-plugin-spoiler/issues",
     "release_notes_url": "https://github.com/moussetc/mattermost-plugin-spoiler/releases/tag/v3.1.0",

--- a/webapp/src/components/spoiler_post_type/spoiler_post_type.jsx
+++ b/webapp/src/components/spoiler_post_type/spoiler_post_type.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import './spoiler_post_type.scss';
 
 const {formatText, messageHtmlToComponent} = window.PostUtils;
 
@@ -16,48 +17,45 @@ export default class SpoilerPostType extends React.PureComponent {
             displaySpoilerContent: false,
         };
 
-        this.revealSpoiler = () => {
+        this.revealSpoiler = (e) => {
+            e.preventDefault();
             if (!this.state.displaySpoilerContent) {
                 this.setState({displaySpoilerContent: true});
             }
         };
-
-        this.renderNormal = (formattedSpoilerCaption, spoilerContent) => {
-            const formattedSpoilerContent = messageHtmlToComponent(formatText(spoilerContent));
-            return (
-                <div>{formattedSpoilerCaption ? <div>{formattedSpoilerCaption}</div> : ''} {formattedSpoilerContent}</div>
-            );
-        };
-
-        this.renderSpoiler = (formattedSpoilerCaption, spoilerContent) => {
-            // don't display real text so emoji, url, image... are not visible
-            const yaourt = Array.from(spoilerContent).
-                map((c) => ((/\s/).test(c) ? c : '_')).join('');
-            const lines = yaourt.split(/\r?\n/).map((line) => messageHtmlToComponent(line));
-            const divProps = {
-                onClick: this.revealSpoiler,
-                style: {background: this.props.theme.centerChannelColor},
-                title: 'Reveal spoiler',
-            };
-            return (
-                <div>
-                    {formattedSpoilerCaption ? <div>{formattedSpoilerCaption}</div> : ''}
-                    {lines.map((line, index) => {
-                        return <div key={index}><span {...divProps}>{line}<br/></span></div>;
-                    })}
-                </div>
-            );
-        };
     }
 
     render() {
-        // Don't use post.message directly as it has a special formatting used by the native apps
         const post = {...this.props.post};
-        const spoilerCaption = messageHtmlToComponent(formatText(post.message || ''));
+        const spoilerCaption = post.message || '';
         const spoilerContent = post.props.CustomSpoilerRawMessage || '';
-        if (this.state.displaySpoilerContent) {
-            return this.renderNormal(spoilerCaption, spoilerContent);
-        }
-        return this.renderSpoiler(spoilerCaption, spoilerContent);
+        const showSpoiler = this.state.displaySpoilerContent;
+
+        const formattedCaption = messageHtmlToComponent(formatText(spoilerCaption));
+        const formattedContent = messageHtmlToComponent(formatText(spoilerContent));
+
+        const divProps = {
+            onClick: this.revealSpoiler,
+        };
+        return (
+            <div>
+                {formattedCaption ? <div>{formattedCaption}</div> : ''}
+                <span
+                    className={`spoiler-content ${showSpoiler ? 'reveal-spoiler' : ''}`}
+                    aria-label='Show spoiler'
+                    aria-expanded={showSpoiler}
+                    tabIndex='0'
+                    role='button'
+                    {...divProps}
+                >
+                    <span
+                        aria-hidden={!showSpoiler}
+                        className='spoilered-text-content'
+                    >
+                        {formattedContent}
+                    </span>
+                </span>
+            </div>
+        );
     }
 }

--- a/webapp/src/components/spoiler_post_type/spoiler_post_type.scss
+++ b/webapp/src/components/spoiler_post_type/spoiler_post_type.scss
@@ -1,0 +1,32 @@
+.spoiler-content {
+
+  &:not(.reveal-spoiler) {
+    display: inline-block;
+    cursor: pointer;
+    color: transparent;
+    user-select: none;
+
+    & * {
+      border-radius: 4px;
+      background-color: var(--center-channel-color);
+      box-decoration-break: clone;
+      -webkit-box-decoration-break: clone;
+      border: none;
+    }
+
+    // Disable event for elements like the code block copy button
+    & > * {
+      pointer-events: none;
+    }
+
+    // Avoid having unwanted elements showing
+    table, a, img, code, br {
+      opacity: 0;
+    }
+
+    // Get background only around the words, not as a full-line rectangle
+    p {
+      display: inline;
+    }
+  }
+}


### PR DESCRIPTION
This requires a complete rework of the render, instead of using fake text character, we display the correct elements but hide them with CSS, and add aria attributes to allow screen readers to access the content.